### PR TITLE
Give root element a class based on the tail's position

### DIFF
--- a/flowtip.coffee
+++ b/flowtip.coffee
@@ -437,6 +437,8 @@ class @FlowTip
       @tail.style.width = "#{position.tail.width}px"
       @tail.style.height = "#{position.tail.height}px"
       @tail.className = "flowtip-tail #{@tailClassName} #{@_tailType(@_region)}"
+      @root.className = @root.className.replace(/tail-at-[\w]+/, "")
+      @root.className = "#{@root.className} tail-at-#{@_tailType(@_region)}"
     else
       @tail.style.display = "none"
 


### PR DESCRIPTION
What do you think of this? I did it this way instead of just resetting the class because in flow there are a few instances where the root has classes added later and I didn't want to delete them and cause breakage. (RequestAnimation at-top at-bottom classes, for example)

If you don't like it we can possibly change those instances where that happens instead.
